### PR TITLE
Updated package.xml for ROS DEP installation.

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -11,24 +11,12 @@ official [ROS 2 installation guide](https://docs.ros.org/en/galactic/Installatio
 
 ### other dependencies
 
-● Install dependencies (be careful with your ROS distribution)
+● Install dependencies with rosdep
 
 ```bash
- Assuming you have sourced the ros environment, same below
-sudo apt install libgflags-dev  ros-$ROS_DISTRO-image-geometry ros-$ROS_DISTRO-camera-info-manager\
-ros-$ROS_DISTRO-image-transport ros-$ROS_DISTRO-image-publisher libgoogle-glog-dev libusb-1.0-0-dev libeigen3-dev
-
-```
-
-● Install libuvc
-
-```bash
-git clone https://github.com/libuvc/libuvc.git
-cd libuvc
-mkdir build && cd build
-cmake .. && make -j4
-sudo make install
-sudo ldconfig # Refreshing the link library
+#sudo rosdep init  #uncomment, if not done
+#rosdep update     #uncomment, if not done
+sudo apt update && rosdep install --from-paths src --ignore-src -r -y
 ```
 
 ### Getting Started

--- a/astra_camera/package.xml
+++ b/astra_camera/package.xml
@@ -26,7 +26,7 @@
   <depend>libusb-1.0</depend>
   <depend>libuvc-dev</depend>
   <depend>message_filters</depend>
-  <depend>nlohmann-json3-dev</depend>
+  <depend>nlohmann-json-dev</depend>
   <depend>rclcpp_components</depend>
   <depend>rclcpp</depend>
   <depend>sensor_msgs</depend>

--- a/astra_camera/package.xml
+++ b/astra_camera/package.xml
@@ -15,12 +15,18 @@
   <depend>astra_camera_msgs</depend>
   <depend>builtin_interfaces</depend>
   <depend>class_loader</depend>
-  <depend>message_filters</depend>
   <depend>camera_info_manager</depend>
   <depend>cv_bridge</depend>
+  <depend>eigen</depend>
   <depend>image_geometry</depend>
   <depend>image_publisher</depend>
   <depend>image_transport</depend>
+  <depend>libgflags-dev</depend>
+  <depend>libgoogle-glog-dev</depend>
+  <depend>libusb-1.0</depend>
+  <depend>libuvc-dev</depend>
+  <depend>message_filters</depend>
+  <depend>nlohmann-json3-dev</depend>
   <depend>rclcpp_components</depend>
   <depend>rclcpp</depend>
   <depend>sensor_msgs</depend>


### PR DESCRIPTION
Dear maintainer,

these packages

```bash
 Assuming you have sourced the ros environment, same below
sudo apt install libgflags-dev  \  
ros-$ROS_DISTRO-image-geometry ros-$ROS_DISTRO-camera-info-manager \
ros-$ROS_DISTRO-image-transport ros-$ROS_DISTRO-image-publisher \  
libgoogle-glog-dev libusb-1.0-0-dev libeigen3-dev
```

and 

```bash
git clone https://github.com/libuvc/libuvc.git
cd libuvc
mkdir build && cd build
cmake .. && make -j4
sudo make install
sudo ldconfig # Refreshing the link library
```

are ALL installable via ROSDEP.  
I have included the packages in `package.xml` and updated the installation instruction in README.md.